### PR TITLE
fixed back button issue

### DIFF
--- a/src/web/index.html
+++ b/src/web/index.html
@@ -265,6 +265,7 @@
         /* Update back button styles to work in the new layout */
         #backBtn {
             margin: 0; /* Remove margins */
+            display: none; /* Initially hidden */
         }
     </style>
 </head>


### PR DESCRIPTION
The "Back" button is visible on page load (experiment list page) because its default style in the HTML was not set to display: none