### PR TITLE
Add faithfulness metric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,5 @@ ide_docs/*
 *.db
 .cursor/
 .trunk/
+AGENTS.md
+.env

--- a/src/promptlab/_experiment.py
+++ b/src/promptlab/_experiment.py
@@ -206,8 +206,21 @@ class Experiment:
                     data[key] = inference
                 else:
                     data[key] = row[value]
+                    
+            # check if the evaluator requires additonal models for evaluation
+            # Auxilary LLM can be used for claim preparation for LLM as judge framework
+            # LLM as judge can be used for evluating the experiment
+            if "judge_llm" in eval:
+                if "auxilary_llm" in eval:
+                    evaluation_result = evaluator.evaluate(data,
+                                                           experiment_config.auxilary_llm,
+                                                           experiment_config.judge_llm)
+                else:
+                    evaluation_result = evaluator.evaluate(data,
+                                                           experiment_config.judge_llm)
+            else:
+                evaluation_result = evaluator.evaluate(data)
 
-            evaluation_result = evaluator.evaluate(data)
             evaluations.append(
                 {"metric": f"{eval.metric}", "result": evaluation_result}
             )

--- a/src/promptlab/_experiment.py
+++ b/src/promptlab/_experiment.py
@@ -206,21 +206,8 @@ class Experiment:
                     data[key] = inference
                 else:
                     data[key] = row[value]
-                    
-            # check if the evaluator requires additonal models for evaluation
-            # Auxilary LLM can be used for claim preparation for LLM as judge framework
-            # LLM as judge can be used for evluating the experiment
-            print(eval)
-            if "judge_llm" in eval:
-                if "auxilary_llm" in eval:
-                    evaluation_result = evaluator.evaluate(data,
-                                                           experiment_config.auxilary_llm,
-                                                           experiment_config.judge_llm)
-                else:
-                    evaluation_result = evaluator.evaluate(data,
-                                                           experiment_config.judge_llm)
-            else:
-                evaluation_result = evaluator.evaluate(data)
+
+            evaluation_result = evaluator.evaluate(data)
 
             evaluations.append(
                 {"metric": f"{eval.metric}", "result": evaluation_result}

--- a/src/promptlab/_experiment.py
+++ b/src/promptlab/_experiment.py
@@ -210,6 +210,7 @@ class Experiment:
             # check if the evaluator requires additonal models for evaluation
             # Auxilary LLM can be used for claim preparation for LLM as judge framework
             # LLM as judge can be used for evluating the experiment
+            print(eval)
             if "judge_llm" in eval:
                 if "auxilary_llm" in eval:
                     evaluation_result = evaluator.evaluate(data,

--- a/src/promptlab/evaluator/faithfulness.py
+++ b/src/promptlab/evaluator/faithfulness.py
@@ -193,7 +193,8 @@ class Faithfulness(Evaluator):
             raise ValueError("No claims were evaluated")
 
         return num_supported_claims / len(claims)
-            
+
+faithfulness = Faithfulness
             
         
         

--- a/src/promptlab/evaluator/faithfulness.py
+++ b/src/promptlab/evaluator/faithfulness.py
@@ -1,0 +1,164 @@
+from promptlab.evaluator.evaluator import Evaluator
+from promptlab.model.model import Model
+import json
+
+
+class Faithfulness(Evaluator):
+    def evaluate(self, data: dict,
+                 auxilary_llm: dict = None,
+                 judge_llm: dict = None):
+        
+        """
+        The Faithfulness metric measures how factually consistent a response is with the retrieved context.
+        It ranges from 0 to 1, with higher scores indicating better consistency.
+        A response is considered faithful if all its claims can be supported by the retrieved context.
+
+        To calculate this:
+        1. Identify all the claims in the response via LLM call using the auxilary_llm model
+        2. Check each claim to see if it can be inferred from the retrieved context using the judge_llm model
+        3. Compute the faithfulness score using the formula:
+        
+        Let, A = # of claims identified by claim_generator
+        B = # of claims supported by the retrieved context as found by the llm_as_judge
+        
+        faithfulness = B/A
+        """
+        
+        if "query" not in data or "context" not in data or "response" not in data:
+            raise ValueError("data dictionary must contain 'query', 'context' and 'response' keys")
+        
+        if judge_llm is None:
+            raise ValueError("Faithfulness uses LLM as a Judge framework. Please provide a judge_llm")
+        
+        # If auxilary_llm is not provided, use judge_llm as fallback
+        if auxilary_llm is None:
+            print("Warning: No claim generation model is provided. Using judge_llm for claim generation.")
+            auxilary_llm = judge_llm
+        
+        try:
+            claims = self.claim_generation(data["answer"], auxilary_llm.model)
+            return self.faithfulness_evaluation(data["retrieved_context"], claims, judge_llm.model)
+        except Exception as e:
+            raise RuntimeError(f"Error during faithfulness evaluation: {str(e)}") from e
+        
+    def claim_generation(self,
+                         query: str,
+                         claim_generator_llm: Model) -> list[str]:
+        
+        claim_generator_system_prompt = """
+        ## Task
+        Read the supplied query passage and list only the factual claims it explicitly asserts.
+        ### Include
+        Concrete statements about specific entities, events, quantities, properties, or relations found verbatim or paraphrased from the text.
+        ### Exclude
+        Background knowledge, definitions, truisms, universal facts, or anything merely implied.
+        ## Output
+        - Return a numbered list.
+        - Each item must be one atomic claim.
+        - Each claim should not use any pronouns.
+        - No commentary, duplicates or assumtions.
+        ## Example
+        <query_passage>
+        "The first ever FIFA world cup took place in 1930 in Uruguay. The first ever champions of the world cup were Uruguay captained by Jose Nasazzi. The runner up was Argentina National Team captained by Juan Jose Higuain."
+        </query_passage>
+        <output_claims>
+        1. The first ever FIFA world cup took place in 1930 in Uruguay
+        2. The first ever champions of the world cup were Uruguay
+        3. The first ever FIFA world cup winning captain was Jose Nasazzi
+        4. The runner up was Argentina National Team
+        5. The runner up of the first ever FIFA world cup was captained by Juan Jose Higuain
+        </output_claims>
+        """
+        
+        claim_generator_user_prompt = """
+        ### Input Query Passage
+        {query_passage}
+        
+        ### Output Claims
+        Determine the claims in the query passage and output them in a numbered list.
+        """
+        
+        claim_generator_user_prompt = claim_generator_user_prompt.replace("{{query_passage}}", query)
+        
+        claim_generator_response = claim_generator_llm.invoke(
+            system_prompt=claim_generator_system_prompt,
+            user_prompt=claim_generator_user_prompt
+        )
+        
+        numbered_claims = claim_generator_response.inference.split("\n")
+        
+        return numbered_claims
+    
+    def faithfulness_evaluation(self,
+                                context: str,
+                                claims: list[str],
+                                judge_llm: Model) -> float:
+        
+        if not claims:
+            raise ValueError("No claims provided for evaluation")
+            
+        if not context:
+            raise ValueError("No context provided for evaluation")
+            
+        judge_system_prompt = """
+        ## Role
+        You are an impartial fact checker. You are provided with a pair of a claim and a context. You must return verdict as 1 if the claim can be directly inferred based on the provided contex. You must return verdict as 0 if the claim cannot be directly inferred based on the provided context.
+        You conduct this fact checker by reasoning step by step.
+        ## Output
+        - Output the judgement as a JSON with two keys: "verdict" and "reasoning"
+        - "verdict" is a boolean value.
+        - "reasoning" is a string that explains your reasoning.
+        - Nothing other than the JSON output is allowed.
+        ## Example
+        <example>
+        <input>
+        "context": "Robert is a CS student with a particularly strong command in compilers, data structure and algorithms"
+        "claim": "Robert is majoring in Music Theory"
+        </input>
+        <output>
+        {"verdict": 0, "reasoning": "Robert is a CS student. There is no mention of Robert doing dual majors. Therefore, Robert is not majoring in Music Theory."}
+        </output>
+        """
+        
+        judge_user_prompt = """
+        Below is the context and claim pair to be checked.
+        ### Context
+        {context}
+        ### Claim
+        {claim}
+        """
+        
+        num_supported_claims = 0
+        
+        for claim in claims:
+            try:
+                formatted_prompt = judge_user_prompt.replace("{{context}}", context)
+                formatted_prompt = formatted_prompt.replace("{{claims}}", claim)
+                
+                judgement = judge_llm.invoke(
+                    system_prompt=judge_system_prompt,
+                    user_prompt=formatted_prompt
+                ).inference
+                
+                try:
+                    verdict = json.loads(judgement)["verdict"]
+                except json.JSONDecodeError as e:
+                    raise ValueError(f"Invalid JSON response from judge_llm: {judgement}") from e
+                except KeyError as e:
+                    raise ValueError(f"Missing 'verdict' key in judge_llm response: {judgement}") from e
+                
+                if verdict == 1:
+                    num_supported_claims += 1
+                    
+            except Exception as e:
+                raise RuntimeError(f"Error evaluating claim '{claim}': {str(e)}") from e
+                
+        if len(claims) == 0:
+            raise ValueError("No claims were evaluated")
+            
+        return num_supported_claims / len(claims)
+            
+            
+        
+        
+        

--- a/src/promptlab/evaluator/faithfulness.py
+++ b/src/promptlab/evaluator/faithfulness.py
@@ -5,12 +5,95 @@ import json
 
 
 class Faithfulness(Evaluator):
-    def evaluate(
-        self,
-        data: dict,
-        auxilary_llm: Optional[Dict] = None,
-        judge_llm: Optional[Dict] = None,
-    ) -> float:
+    # Class-level prompt templates
+    CLAIM_GENERATOR_SYSTEM_PROMPT = """
+    ## Task
+    Read the supplied query passage and list only the factual claims it explicitly asserts.
+    ### Include
+    Concrete statements about specific entities, events, quantities, properties, or relations found verbatim or paraphrased from the text.
+    ### Exclude
+    Background knowledge, definitions, truisms, universal facts, or anything merely implied.
+    ## Output
+    - Return a numbered list.
+    - Each item must be one atomic claim.
+    - Each claim should not use any pronouns.
+    - No commentary, duplicates or assumtions.
+    ## Example
+    <query_passage>
+    "The first ever FIFA world cup took place in 1930 in Uruguay. The first ever champions of the world cup were Uruguay captained by Jose Nasazzi. The runner up was Argentina National Team captained by Juan Jose Higuain."
+    </query_passage>
+    <output_claims>
+    1. The first ever FIFA world cup took place in 1930 in Uruguay
+    2. The first ever champions of the world cup were Uruguay
+    3. The first ever FIFA world cup winning captain was Jose Nasazzi
+    4. The runner up was Argentina National Team
+    5. The runner up of the first ever FIFA world cup was captained by Juan Jose Higuain
+    </output_claims>
+    """
+
+    CLAIM_GENERATOR_USER_PROMPT = """
+    ### Input Query Passage
+    {query_passage}
+
+    ### Output Claims
+    Determine the claims in the query passage and output them in a numbered list.
+    """
+
+    JUDGE_SYSTEM_PROMPT = """
+    ## Role
+    You are an impartial fact checker. You are provided with a pair of a claim and a context. You must return verdict as 1 if the claim can be directly inferred based on the provided contex. You must return verdict as 0 if the claim cannot be directly inferred based on the provided context.
+    You conduct this fact checker by reasoning step by step.
+    ## Output
+    - Output the judgement as a JSON with two keys: "verdict" and "reasoning"
+    - "verdict" is a boolean value.
+    - "reasoning" is a string that explains your reasoning.
+    - Nothing other than the JSON output is allowed.
+    ## Example
+    <example>
+    <input>
+    "context": "Robert is a CS student with a particularly strong command in compilers, data structure and algorithms"
+    "claim": "Robert is majoring in Music Theory"
+    </input>
+    <output>
+    {"verdict": 0, "reasoning": "Robert is a CS student. There is no mention of Robert doing dual majors. Therefore, Robert is not majoring in Music Theory."}
+    </output>
+    """
+
+    JUDGE_USER_PROMPT = """
+    Below is the context and claim pair to be checked.
+    ### Context
+    {context}
+    ### Claim
+    {claim}
+    """
+
+    def __init__(self,
+                 judge_llm: Optional[Dict] = None,
+                 auxilary_llm: Optional[Dict] = None):
+        """
+        Initialize the Faithfulness evaluator.
+
+        Args:
+            judge_llm: Dictionary containing the model for claim verification
+            auxilary_llm: Dictionary containing the model for claim generation
+        """
+        # Validate judge_llm
+        if judge_llm is None:
+            raise ValueError("Faithfulness evaluation requires a judge_llm model")
+        if "model" not in judge_llm:
+            raise ValueError("judge_llm dictionary must contain a 'model' key")
+        
+        # If auxilary_llm is not provided, use judge_llm as fallback
+        if auxilary_llm is None:
+            print("Warning: No claim generation model is provided. Using judge_llm for claim generation.")
+            auxilary_llm = judge_llm
+        elif "model" not in auxilary_llm:
+            raise ValueError("auxilary_llm dictionary must contain a 'model' key")
+
+        self.judge_llm = judge_llm["model"]
+        self.auxilary_llm = auxilary_llm["model"]
+
+    def evaluate(self, data: dict) -> float:
         """
         Evaluate the faithfulness of a response against its context.
 
@@ -19,121 +102,47 @@ class Faithfulness(Evaluator):
                 - query: The original query
                 - context: The context to evaluate against
                 - response: The response to evaluate
-            auxilary_llm: Dictionary containing the model for claim generation
-            judge_llm: Dictionary containing the model for claim verification
 
         Returns:
             float: Faithfulness score between 0 and 1
-
-        The Faithfulness metric measures how factually consistent a response is with the retrieved context.
-        It ranges from 0 to 1, with higher scores indicating better consistency.
-        A response is considered faithful if all its claims can be supported by the retrieved context.
-
-        To calculate this:
-        1. Identify all the claims in the response via LLM call using the auxilary_llm model
-        2. Check each claim to see if it can be inferred from the retrieved context using the judge_llm model
-        3. Compute the faithfulness score using the formula:
-
-        Let, A = # of claims identified by claim_generator
-        B = # of claims supported by the retrieved context as found by the llm_as_judge
-
-        faithfulness = B/A
         """
         # Validate input data
         required_keys = ["query", "context", "response"]
         if not all(key in data for key in required_keys):
-            raise ValueError(
-                f"data dictionary must contain {', '.join(required_keys)} keys"
-            )
-
-        # Validate judge_llm
-        if judge_llm is None:
-            raise ValueError("Faithfulness evaluation requires a judge_llm model")
-        if "model" not in judge_llm:
-            raise ValueError("judge_llm dictionary must contain a 'model' key")
-
-        # If auxilary_llm is not provided, use judge_llm as fallback
-        if auxilary_llm is None:
-            print(
-                "Warning: No claim generation model is provided. Using judge_llm for claim generation."
-            )
-            auxilary_llm = judge_llm
-        elif "model" not in auxilary_llm:
-            raise ValueError("auxilary_llm dictionary must contain a 'model' key")
+            raise ValueError(f"data dictionary must contain {', '.join(required_keys)} keys")
 
         try:
-            claims = self.claim_generation(data["response"], auxilary_llm["model"])
-            return self.faithfulness_evaluation(
-                data["context"], claims, judge_llm["model"]
-            )
+            claims = self._claim_generation(data["response"])
+            return self._faithfulness_evaluation(data["context"], claims)
         except Exception as e:
             raise RuntimeError(f"Error during faithfulness evaluation: {str(e)}") from e
 
-    def claim_generation(self, response: str, claim_generator_llm: Model) -> List[str]:
+    def _claim_generation(self, response: str) -> List[str]:
         """
         Generate claims from the response using the provided LLM.
 
         Args:
             response: The response text to generate claims from
-            claim_generator_llm: The LLM model to use for claim generation
 
         Returns:
             List of claims extracted from the response
         """
-        claim_generator_system_prompt = """
-        ## Task
-        Read the supplied query passage and list only the factual claims it explicitly asserts.
-        ### Include
-        Concrete statements about specific entities, events, quantities, properties, or relations found verbatim or paraphrased from the text.
-        ### Exclude
-        Background knowledge, definitions, truisms, universal facts, or anything merely implied.
-        ## Output
-        - Return a numbered list.
-        - Each item must be one atomic claim.
-        - Each claim should not use any pronouns.
-        - No commentary, duplicates or assumtions.
-        ## Example
-        <query_passage>
-        "The first ever FIFA world cup took place in 1930 in Uruguay. The first ever champions of the world cup were Uruguay captained by Jose Nasazzi. The runner up was Argentina National Team captained by Juan Jose Higuain."
-        </query_passage>
-        <output_claims>
-        1. The first ever FIFA world cup took place in 1930 in Uruguay
-        2. The first ever champions of the world cup were Uruguay
-        3. The first ever FIFA world cup winning captain was Jose Nasazzi
-        4. The runner up was Argentina National Team
-        5. The runner up of the first ever FIFA world cup was captained by Juan Jose Higuain
-        </output_claims>
-        """
+        formatted_prompt = self.CLAIM_GENERATOR_USER_PROMPT.format(query_passage=response)
 
-        claim_generator_user_prompt = """
-        ### Input Query Passage
-        {query_passage}
-
-        ### Output Claims
-        Determine the claims in the query passage and output them in a numbered list.
-        """
-
-        claim_generator_user_prompt = claim_generator_user_prompt.format(
-            query_passage=response
-        )
-
-        claim_generator_response = claim_generator_llm.invoke(
-            system_prompt=claim_generator_system_prompt,
-            user_prompt=claim_generator_user_prompt,
+        claim_generator_response = self.auxilary_llm.invoke(
+            system_prompt=self.CLAIM_GENERATOR_SYSTEM_PROMPT,
+            user_prompt=formatted_prompt
         )
 
         return claim_generator_response.inference.split("\n")
 
-    def faithfulness_evaluation(
-        self, context: str, claims: List[str], judge_llm: Model
-    ) -> float:
+    def _faithfulness_evaluation(self, context: str, claims: List[str]) -> float:
         """
         Evaluate the faithfulness of claims against the provided context.
 
         Args:
             context: The context to evaluate claims against
             claims: List of claims to evaluate
-            judge_llm: The LLM model to use for evaluation
 
         Returns:
             Faithfulness score between 0 and 1
@@ -144,56 +153,23 @@ class Faithfulness(Evaluator):
         if not context:
             raise ValueError("No context provided for evaluation")
 
-        judge_system_prompt = """
-        ## Role
-        You are an impartial fact checker. You are provided with a pair of a claim and a context. You must return verdict as 1 if the claim can be directly inferred based on the provided contex. You must return verdict as 0 if the claim cannot be directly inferred based on the provided context.
-        You conduct this fact checker by reasoning step by step.
-        ## Output
-        - Output the judgement as a JSON with two keys: "verdict" and "reasoning"
-        - "verdict" is a boolean value.
-        - "reasoning" is a string that explains your reasoning.
-        - Nothing other than the JSON output is allowed.
-        ## Example
-        <example>
-        <input>
-        "context": "Robert is a CS student with a particularly strong command in compilers, data structure and algorithms"
-        "claim": "Robert is majoring in Music Theory"
-        </input>
-        <output>
-        {"verdict": 0, "reasoning": "Robert is a CS student. There is no mention of Robert doing dual majors. Therefore, Robert is not majoring in Music Theory."}
-        </output>
-        """
-
-        judge_user_prompt = """
-        Below is the context and claim pair to be checked.
-        ### Context
-        {context}
-        ### Claim
-        {claim}
-        """
-
         num_supported_claims = 0
 
         for claim in claims:
             try:
-                formatted_prompt = judge_user_prompt.format(
-                    context=context, claim=claim
-                )
+                formatted_prompt = self.JUDGE_USER_PROMPT.format(context=context, claim=claim)
 
-                judgement = judge_llm.invoke(
-                    system_prompt=judge_system_prompt, user_prompt=formatted_prompt
+                judgement = self.judge_llm.invoke(
+                    system_prompt=self.JUDGE_SYSTEM_PROMPT,
+                    user_prompt=formatted_prompt
                 ).inference
 
                 try:
                     verdict = json.loads(judgement)["verdict"]
                 except json.JSONDecodeError as e:
-                    raise ValueError(
-                        f"Invalid JSON response from judge_llm: {judgement}"
-                    ) from e
+                    raise ValueError(f"Invalid JSON response from judge_llm: {judgement}") from e
                 except KeyError as e:
-                    raise ValueError(
-                        f"Missing 'verdict' key in judge_llm response: {judgement}"
-                    ) from e
+                    raise ValueError(f"Missing 'verdict' key in judge_llm response: {judgement}") from e
 
                 if verdict == 1:
                     num_supported_claims += 1

--- a/src/promptlab/evaluator/faithfulness.py
+++ b/src/promptlab/evaluator/faithfulness.py
@@ -80,8 +80,6 @@ class Faithfulness(Evaluator):
         # Validate judge_llm
         if judge_llm is None:
             raise ValueError("Faithfulness evaluation requires a judge_llm model")
-        if "model" not in judge_llm:
-            raise ValueError("judge_llm dictionary must contain a 'model' key")
         
         # If claimify_llm is not provided, use judge_llm as fallback
         if claimify_llm is None:

--- a/src/promptlab/evaluator/faithfulness.py
+++ b/src/promptlab/evaluator/faithfulness.py
@@ -1,6 +1,6 @@
 from promptlab.evaluator.evaluator import Evaluator
 from promptlab.model.model import Model
-from typing import Dict, List, Optional
+from typing import List
 import json
 
 

--- a/src/promptlab/evaluator/faithfulness.py
+++ b/src/promptlab/evaluator/faithfulness.py
@@ -68,14 +68,14 @@ class Faithfulness(Evaluator):
     """
 
     def __init__(self,
-                 judge_llm: Optional[Dict] = None,
-                 auxilary_llm: Optional[Dict] = None):
+                 judge_llm: Model = None,
+                 claimify_llm: Model = None):
         """
         Initialize the Faithfulness evaluator.
 
         Args:
             judge_llm: Dictionary containing the model for claim verification
-            auxilary_llm: Dictionary containing the model for claim generation
+            claimify_llm: Dictionary containing the model for claim generation
         """
         # Validate judge_llm
         if judge_llm is None:
@@ -83,15 +83,13 @@ class Faithfulness(Evaluator):
         if "model" not in judge_llm:
             raise ValueError("judge_llm dictionary must contain a 'model' key")
         
-        # If auxilary_llm is not provided, use judge_llm as fallback
-        if auxilary_llm is None:
+        # If claimify_llm is not provided, use judge_llm as fallback
+        if claimify_llm is None:
             print("Warning: No claim generation model is provided. Using judge_llm for claim generation.")
-            auxilary_llm = judge_llm
-        elif "model" not in auxilary_llm:
-            raise ValueError("auxilary_llm dictionary must contain a 'model' key")
+            claimify_llm = judge_llm
 
-        self.judge_llm = judge_llm["model"]
-        self.auxilary_llm = auxilary_llm["model"]
+        self.judge_llm = judge_llm
+        self.claimify_llm = claimify_llm
 
     def evaluate(self, data: dict) -> float:
         """
@@ -129,7 +127,7 @@ class Faithfulness(Evaluator):
         """
         formatted_prompt = self.CLAIM_GENERATOR_USER_PROMPT.format(query_passage=response)
 
-        claim_generator_response = self.auxilary_llm.invoke(
+        claim_generator_response = self.claimify_llm.invoke(
             system_prompt=self.CLAIM_GENERATOR_SYSTEM_PROMPT,
             user_prompt=formatted_prompt
         )


### PR DESCRIPTION
## Summary of PR

- Added faithfulness.metric as per the definition found in the most common eval libraries, with slight modification
  - Faithfulness as metric is NOT shown/or use the "query"
  - Faithfulness is strictly calculated based on `context` and `response`
  - Reason being: Faithfulness, in its formulation, does not concern about the `query`. So the models should NOT bias their output having the `qurey` itself in the context
  
- Faithfulness metric requires 2 LLM inference. These LLMs are set as a part of instantiation of the `Faithfulness` evaluator
  - We need a `claimilfy_llm`. **This inference is done from within the Evaluator, not outside it**
  - We need a `judge_llm` inference. The # of inferences depends on the claims extracted by `claimify` part
  